### PR TITLE
Add Python 2 backward compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
 # nspBuild
-Convert NCA or XCI to NSP Format using Python 3
-
-Todo: Add Python 2 support
+Convert NCA or XCI to NSP Format using Python

--- a/nspBuild.py
+++ b/nspBuild.py
@@ -1,6 +1,11 @@
 import sys, os
 from struct import pack as pk, unpack as upk
 
+try:
+    input = raw_input
+except NameError:
+    pass
+
 def gen_header(argc, argv):
     stringTable = '\x00'.join([os.path.basename(file) for file in argv[1:]])
     headerSize = 0x10 + (argc-1)*0x18 + len(stringTable)
@@ -31,7 +36,7 @@ def gen_header(argc, argv):
 
 def mk_nsp(argc, argv):
     if argc == 1:
-        print('Usage is: %s file1 file 2 ...' % sys.argv[0])
+        print('Usage is: %s file1 file2 ...' % sys.argv[0])
         return 1
         
     name = input('Name of output nsp? ')


### PR DESCRIPTION
Tested with Python 2.7.15 and Anaconda Python 3.6.5 in Windows 10 x64. Both drag-dropping and command-line worked. Curiously, Python 3 is slightly and consistently slower (took about 20% longer) than Python 2 with the xci I tested.