### PR TITLE
Take output file from command line instead of prompting

### DIFF
--- a/nspBuild.py
+++ b/nspBuild.py
@@ -7,24 +7,24 @@ except NameError:
     pass
 
 def gen_header(argc, argv):
-    stringTable = '\x00'.join([os.path.basename(file) for file in argv[1:]])
-    headerSize = 0x10 + (argc-1)*0x18 + len(stringTable)
+    stringTable = '\x00'.join([os.path.basename(file) for file in argv[2:]])
+    headerSize = 0x10 + (argc-2)*0x18 + len(stringTable)
     remainder = 0x10 - headerSize%0x10
     headerSize += remainder
     
-    fileSizes = [os.path.getsize(file) for file in argv[1:]]
-    fileOffsets = [sum(fileSizes[:n]) for n in range(argc-1)]
+    fileSizes = [os.path.getsize(file) for file in argv[2:]]
+    fileOffsets = [sum(fileSizes[:n]) for n in range(argc-2)]
     
-    fileNamesLengths = [len(os.path.basename(file))+1 for file in argv[1:]] # +1 for the \x00 separator
-    stringTableOffsets = [sum(fileNamesLengths[:n]) for n in range(argc-1)]
+    fileNamesLengths = [len(os.path.basename(file))+1 for file in argv[2:]] # +1 for the \x00 separator
+    stringTableOffsets = [sum(fileNamesLengths[:n]) for n in range(argc-2)]
     
     header =  b''
     header += b'PFS0'
-    header += pk('<I', argc-1)
+    header += pk('<I', argc-2)
     header += pk('<I', len(stringTable)+remainder)
     header += b'\x00\x00\x00\x00'
     
-    for n in range(argc-1):
+    for n in range(argc-2):
         header += pk('<Q', fileOffsets[n])
         header += pk('<Q', fileSizes[n])
         header += pk('<I', stringTableOffsets[n])
@@ -35,18 +35,18 @@ def gen_header(argc, argv):
     return header   
 
 def mk_nsp(argc, argv):
-    if argc == 1:
-        print('Usage is: %s file1 file2 ...' % sys.argv[0])
+    if argc < 3:
+        print('Usage is: %s output file1 file2 ...' % sys.argv[0])
         return 1
         
-    name = input('Name of output nsp? ')
-    outf = open(os.path.join(os.path.dirname(__file__), name), 'wb')
+    name = argv[1]
+    outf = open(name, 'wb')
     
     print('Generating header...')
     header = gen_header(argc, argv)
     outf.write(header)
     
-    for f in argv[1:]:
+    for f in argv[2:]:
         print('Appending %s...' % f)
         with open(f, 'rb') as inf:
             while True:


### PR DESCRIPTION
This allows using nspBuild in scripts, so that it can be used in combination with other tools like hactool and dedbae to do complex things in an automated fashion.